### PR TITLE
Fix byte compaction for chunks with low values

### DIFF
--- a/pdf417gen/compaction/byte.py
+++ b/pdf417gen/compaction/byte.py
@@ -23,6 +23,6 @@ def _compact_chunk(chunk):
     digits = [i for i in chunk]
 
     if len(chunk) == 6:
-        return switch_base(digits, 256, 900)
+        return switch_base(digits, 256, 900, 5)
 
     return digits

--- a/pdf417gen/util.py
+++ b/pdf417gen/util.py
@@ -6,18 +6,22 @@ def from_base(digits, base):
     return sum(v * (base ** (len(digits) - k - 1)) for k, v in enumerate(digits))
 
 
-def to_base(value, base):
+def to_base(value, base, target_length=None):
     digits = []
 
     while value > 0:
         digits.insert(0, value % base)
         value //= base
 
+    if target_length:
+        # left-pad with 0s to reach target_length
+        return [0] * (target_length - len(digits)) + digits
+
     return digits
 
 
-def switch_base(digits, source_base, target_base):
-    return to_base(from_base(digits, source_base), target_base)
+def switch_base(digits, source_base, target_base, target_length):
+    return to_base(from_base(digits, source_base), target_base, target_length)
 
 
 def chunks(iterable, size):

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -13,7 +13,7 @@ def test_byte_compactor():
 
     assert do_compact("alcool") == [163, 238, 432, 766, 244]
     assert do_compact("alcoolique") == [163, 238, 432, 766, 244, 105, 113, 117, 101]
-
+    assert do_compact("\00alc\00l") == [0, 573, 880, 505, 712]
 
 def test_text_compactor_interim():
     def do_compact(str):


### PR DESCRIPTION
When encoding a 6-byte chunk, the byte compaction must yield exactly 5 codewords, in order to properly decode to the same 6 bytes.

The `to_base()` util function had no notion of the expected number of result digits, so it couldn't add the necessary leading 0s when the base-900 encoded value was small enough to fit in 4 "digits" (codewords) This can happen when the leftmost input byte is 0, and the next one is low.

This would lead to off-by-one situations and the codewords would be unexpectedly shifted by one, ending with an incorrect PDF417 rendering.

Extended `test_compaction` to cover this case.